### PR TITLE
Create event loop if one doesn't exist

### DIFF
--- a/goodfire/utils/asyncio.py
+++ b/goodfire/utils/asyncio.py
@@ -16,7 +16,12 @@ def run_async_safely(coro: Coroutine[Any, Any, T]) -> T:
     Returns:
         The result of the coroutine
     """
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # Create a new event loop if one doesn't exist
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     if loop.is_running():
         result_queue: Queue[tuple[str, Any]] = Queue()


### PR DESCRIPTION
You currently can't open multiple threads to call client.features.activations (or the other methods) because `run_async_safely` assumes that an event loop exists, leading to an error saying "event loop not running". This patch creates a new loop if one doesn't exist yet.