### PR TITLE
don't pin dependencies to specific versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-ipywidgets = "^8.1.5"
-httpx = "^0.27.2"
-pydantic = "^2.9.2"
-scipy = "^1.14.1"
-scikit-learn = "^1.6.0"
+python = ">= 3.10"
+ipywidgets = ">= 8.1.5"
+httpx = ">= 0.27.2"
+pydantic = ">= 2.9.2"
+scipy = ">= 1.14.1"
+scikit-learn = ">= 1.6.0"
 numpy = ">= 1.26.4"
 
 


### PR DESCRIPTION
Rather, allow the same versions or any greater version. This will resolve https://github.com/goodfire-ai/goodfire-sdk/issues/3.

Here is some additional discussion on why hard pinning or upper bounding version constraints can end up in a dead end where packages don't work together: https://iscinumpy.dev/post/bound-version-constraints/.  

Note that currently installing `goodfire` results in a pip error when installing either `mistralai` or `google-genai` (both of which require httpx >= 0.28 whereas `goodfire` is pinned at 0.27.2.

This will enable us to restore the Goodfire provider to Inspect AI: https://github.com/UKGovernmentBEIS/inspect_ai/pull/2170

